### PR TITLE
Bug Fixes: Element path names + Infinite loop with malformed syntax

### DIFF
--- a/src/syntax/jsx.rs
+++ b/src/syntax/jsx.rs
@@ -101,7 +101,7 @@ impl syn::parse::Parse for Element {
         let f = input.fork();
 
         let _: Token![<] = f.parse()?;
-        let _: syn::Ident = f.parse()?;
+        let _: syn::Path = f.parse()?;
         let _: Vec<Attribute> = parse_attrs(&f)?;
 
         if f.peek(Token![/]) {
@@ -496,5 +496,12 @@ mod tests {
         "#).expect("Valid parse");
 
         println!("{x:#?}");
+    }
+
+    #[test]
+    fn element_path_test() {
+        let _: Element = syn::parse_str(r#"<icon::Cactus color="green" />"#).expect("Valid parse");
+        let _: Element = syn::parse_str(r#"<model::Button>Hello World!</model::Button>"#).expect("Valid parse");
+        let _: Element = syn::parse_str(r#"<model::Button primary>Hello World!</model::Button>"#).expect("Valid parse");
     }
 }


### PR DESCRIPTION
These bugs have been fixed, as well some additional accompanying tests. 

### Bug 1
Closing #8 
This was a mistake when “peeking” for the start of an opening/self-closing element tag: `syn::Path` should have been used over `syn::Ident` as not all tokens were parsed (even if they should have!) 

### Bug 2
Closing #9 
After triage, the culprit is with the parser of `Text` -- it allowed for blank contents, whilst still being `Ok(...)` -- this is a logic error.

1. This means when the parser looks at `/Columns>`, it will parse `/Columns` as `Text`, leaving `>` behind.
2. Then, as `>` is not allowed in text, it will immediately return an empty `Text()`, leaving `>` behind.
3. Step 2. Repeats forever, as the `ClosedElement` parser never sees a closing tag.

Solving this was as easy as adding a `.is_empty()` check, then returning an appropriate error if `Text` could not parse anything. 